### PR TITLE
[BUGFIX] Configure a PHP platform in the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,9 @@
         "squizlabs/php_codesniffer": "^3.5.3"
     },
     "config": {
+        "platform": {
+            "php": "7.2.9"
+        },
         "preferred-install": {
             "*": "dist"
         },


### PR DESCRIPTION
This ensures that a `composer update` run on PHP 7.3. or 7.4
will not install package versions incompatible with PHP 7.2.

Fixes #14