### PR TITLE
[BUGFIX] Add the .0 suffix to the PHP version requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "~7.2 || ~7.3 || ~7.4",
+        "php": "~7.2.0 || ~7.3.0 || ~7.4.0",
         "ttn/books": "@dev",
         "ttn/site": "@dev",
         "ttn/tea": "@dev",


### PR DESCRIPTION
Due to the way the `~` operator works for Composer, a `~7.2` PHP
version requirement would allow all PHP 7 versions, not just 7.2.x.

Fixes #13