### PR TITLE
[BUGFIX] Ensure that TYPO3 CMS < 9.5.20 cannot be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ttn/site": "@dev",
         "ttn/tea": "@dev",
         "typo3/cms-backend": "^9.5",
-        "typo3/cms-core": "^9.5.19",
+        "typo3/cms-core": "^9.5.20",
         "typo3/cms-fluid-styled-content": "^9.5",
         "typo3/cms-filelist": "^9.5",
         "typo3/cms-frontend": "^9.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0def0e1df0729a15948123c370d836cb",
+    "content-hash": "c356d862c206b5ddb618ccc75afa3f56",
     "packages": [
         {
             "name": "cogpowered/finediff",


### PR DESCRIPTION
This makes sure we always have the latest security release.