### PR TITLE
[TASK] Allow Composer plugins for development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,12 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "typo3/cms-composer-installers": true,
+            "typo3/class-alias-loader": true,
+            "helhum/typo3-console-plugin": true
+        }
     },
     "scripts": {
         "post-autoload-dump": [


### PR DESCRIPTION
This avoids changes to the `composer.json` with Composer 2.2.